### PR TITLE
Switch to using "blade class" consistently instead of "blade type"

### DIFF
--- a/vtds_platform_ubuntu/private/private_platform.py
+++ b/vtds_platform_ubuntu/private/private_platform.py
@@ -104,7 +104,7 @@ class PrivatePlatform:
             )
             connections.copy_to(
                 self.blade_config_path, "/root/blade_platform_config.yaml",
-                "upload-platform-config-to"
+                False, "upload-platform-config-to"
             )
             info_msg(
                 "copying '%s' to all Virtual Blades at '/root/%s'" % (
@@ -113,7 +113,7 @@ class PrivatePlatform:
             )
             connections.copy_to(
                 DEPLOY_SCRIPT_PATH, "/root/%s" % DEPLOY_SCRIPT_NAME,
-                "upload-platform-deploy-script-to"
+                False, "upload-platform-deploy-script-to"
             )
             cmd = (
                 "chmod 755 ./%s;"

--- a/vtds_platform_ubuntu/private/private_platform.py
+++ b/vtds_platform_ubuntu/private/private_platform.py
@@ -117,7 +117,7 @@ class PrivatePlatform:
             )
             cmd = (
                 "chmod 755 ./%s;"
-                "python3 ./%s {{ blade_type }} blade_platform_config.yaml" % (
+                "python3 ./%s {{ blade_class }} blade_platform_config.yaml" % (
                     DEPLOY_SCRIPT_NAME,
                     DEPLOY_SCRIPT_NAME
                 )

--- a/vtds_platform_ubuntu/private/scripts/deploy_platform_to_blade.py
+++ b/vtds_platform_ubuntu/private/scripts/deploy_platform_to_blade.py
@@ -306,7 +306,7 @@ def entrypoint(usage_msg, main_func):
 
 if __name__ == '__main__':
     USAGE_MSG = """
-usage: deploy_to_blade blade_type config_path
+usage: deploy_to_blade blade_class config_path
 
 Where:
 

--- a/vtds_platform_ubuntu/private/scripts/deploy_platform_to_blade.py
+++ b/vtds_platform_ubuntu/private/scripts/deploy_platform_to_blade.py
@@ -102,7 +102,7 @@ def info_msg(msg):
     write_err("INFO: %s\n" % msg)
 
 
-def run_cmd(cmd, args, stdin=sys.stdin, timeout=None):
+def run_cmd(cmd, args, stdin=sys.stdin, timeout=None, check=True):
     """Run a command with output on stdout and errors on stderr
 
     """
@@ -145,12 +145,13 @@ def run_cmd(cmd, args, stdin=sys.stdin, timeout=None):
                 str(err)
             )
         ) from err
-    if exitval != 0:
+    if exitval != 0 and check:
         fmt = (
             "command '%s' failed" if not signaled
             else "command '%s' timed out and was killed"
         )
         raise ContextualError(fmt % " ".join([cmd, *args]))
+    return exitval
 
 
 def read_config(config_file):
@@ -177,7 +178,10 @@ def prepare_package_installer():
     """
     run_cmd("apt", ["update"])
     run_cmd("apt", ["upgrade", "-y"])
-    run_cmd("apt", ["install", "-y", "apt-utils"])
+    # For some reason I got a failure when this wasn't done even though
+    # it shouldn't need to be done. Sticking it in without checking its
+    # result just in case.
+    run_cmd("apt", ["install", "-y", "apt-utils", "apt"], check=False)
 
 
 def preconfigure_packages(settings):


### PR DESCRIPTION
## Summary and Scope

Switch to consistent use of "blade class" to make the code easier to read and to adapt to the provider layer API change that does the same thing.