### PR TITLE
Move deletion of deleted python packages to consolidate

### DIFF
--- a/vtds_platform_ubuntu/private/platform.py
+++ b/vtds_platform_ubuntu/private/platform.py
@@ -76,14 +76,13 @@ class Platform(PlatformAPI):
         }
 
     def consolidate(self):
-        return
-
-    def prepare(self):
         self.provider_api = self.stack.get_provider_api()
         python_config = self.config.get('python', {})
         python_config['modules'] = self.__clean_deleted_py_modules(
             python_config.get('modules', {})
         )
+
+    def prepare(self):
         blade_config = self.config
         with open(self.blade_config_path, 'w', encoding='UTF-8') as conf:
             safe_dump(blade_config, stream=conf)


### PR DESCRIPTION
## Summary and Scope

The preparation of each layer for further operations was recently broken into two phases: 'consolidate' and 'prepare' instead of just the single 'prepare' phase we had before. This was done to allow the application layer (specifically, though all layers can take advantage of it) to use API methods on lower layers that modify the configuration of the lower layers prior to their deployment. The consolidate operation needs to complete all layer specific operations on the layer's configuration prior to allowing the next layer's consolidate operation to run. There was code in the vtds-platform-ubuntu layer implementation that cleans up the list of python modules in the platform configuration, but that code was in the prepare() method not the consolidate() method. That resulted in weird behavior with respect to viewing the final configuration and with respect to deploying and removing vTDS clusters. This PR moves that code to the consolidate() method.

This was tested by both deploying and removing a vTDS cluster as well as by showing the final configuration of a vTDS cluster.

