### PR TITLE
Add mkisofs to virtualization packages

### DIFF
--- a/vtds_platform_ubuntu/private/config/config.yaml
+++ b/vtds_platform_ubuntu/private/config/config.yaml
@@ -47,6 +47,7 @@ platform:
         - libvirt-clients
         - libguestfs-tools
         - python3-libvirt
+        - mkisofs
       # Preconfiguration settings supplied to debconf-set-selections to allow
       # correct unattended installation of the above packages
       preconfig_settings: []


### PR DESCRIPTION
## Summary and Scope

To support creation of virtual machines using ISO images, the Virtual Blades set up by the Ubuntu platform need to provide the mkisofs tool. This PR adds that tool.

## Issues and Related PRs

* Supports [VSHA-648](https://jira-pro.it.hpe.com:8443/browse/VSHA-648)

## Testing

Tested on vTDS using the openCHAMI configuration.
