### PR TITLE
Add Supporting Utilities Needed to Deploy sushy-emulator on Virtual Blades

### DIFF
--- a/vtds_platform_ubuntu/private/config/config.yaml
+++ b/vtds_platform_ubuntu/private/config/config.yaml
@@ -48,6 +48,11 @@ platform:
         - libguestfs-tools
         - python3-libvirt
         - mkisofs
+        - libvirt-dev
+        # Apache Utils allows us to have an htpasswd file for
+        # SushyTools to use. This is as good a place as any to
+        # put it.
+        - apache2-utils
       # Preconfiguration settings supplied to debconf-set-selections to allow
       # correct unattended installation of the above packages
       preconfig_settings: []
@@ -139,4 +144,19 @@ platform:
         source_type: git
         metadata:
           url: "https://github.com/Cray-HPE/sushy-tools-vshasta-v3.git"
+          version: With-Libvirt-By-Name
+      libvirt-python:
+        # Install 'libvirt-python' to support Sushy-Tools interactions
+        # with libvirt.
+        module_name: libvirt-python
+        delete: false
+        source_type: pypi
+        metadata:
+          version: null
+      yaml:
+        # Install 'pyyaml' as a dependency for the node deploy scripts.
+        module_name: pyyaml
+        delete: false
+        source_type: pypi
+        metadata:
           version: null


### PR DESCRIPTION
## Summary and Scope

To get `sushy-emulator` to deploy on Virtual Blades and function correctly, we need the apache2-utils package so we can generate `htpasswd` files for `sushy-emulator` to use, we need the pyyaml library for python and we need both the `libvirt-dev` package and the `libvirt-python` python module to support running `sushy-emulator`. This PR changes the base configuration of vtds-platform-ubuntu to install those packages on deployment.

## Issues and Related PRs

* Relates to VSHA-670

## Testing

Tested by building OpenCHAMI on vTDS and verifying that Sushy-Tools is correctly installed and works on that platform as expected.
