### PR TITLE
Add nginx to the base set of packages for the blade

### DIFF
--- a/vtds_platform_ubuntu/private/config/config.yaml
+++ b/vtds_platform_ubuntu/private/config/config.yaml
@@ -65,6 +65,46 @@ platform:
       # stopped / disabled after installation to avoid conflicts or
       # save resources.
       services_disable: []
+    sushy_emulator_support:
+      # List of blade classes where the packages should be
+      # installed. If this is null, then the packages will be
+      # installed everywhere. If this is empty packages will not be
+      # installed anywhere. Otherwise packages will only be installed
+      # on instances of the blade classes in this list.
+      blade_classes: null
+      # List of packages in this category.
+      packages:
+        # Libvirt-dev is a dependency for building packages that
+        # sushy-emulator depends on.
+        - libvirt-dev
+        # Apache Utils allows us to have an htpasswd file for
+        # SushyTools to use. This is as good a place as any to
+        # put it.
+        - apache2-utils
+        # We front sushy-tools on the blades with nginx to make it more
+        # reliable. Install it disabled for now so that we don't have it
+        # sitting on a port until we have properly configured it and
+        # want it.
+        - nginx
+      # Preconfiguration settings supplied to debconf-set-selections to allow
+      # correct unattended installation of the above packages
+      preconfig_settings: []
+      
+      # List of services provided by these packages that should be
+      # started / enabled after installation.
+      services_enable: []
+      # List of services provided by these packages that should be
+      # stopped / disabled after installation to avoid conflicts or
+      # save resources.
+      services_disable:
+        - nginx
+    network_virtualization:
+      blade_classes: null
+      packages:
+        - bridge-utils
+      preconfig_settings: []
+      services_enable: []
+      services_disable: []
     network_virtualization:
       blade_classes: null
       packages:


### PR DESCRIPTION
## Summary and Scope

The platform layer installs `sushy-tools` on virtual blades to allow them to function as virtual BMCs on systems that want that functionality. While this is useful, `sushy-tools` will be unreliable if exposed directly to the network(s) on the blade, so this PR adds the installation of `nginx` to be used as a reverse proxy for `sushy-emulator`, providing HTTPS support and placing a more robust web-server ahead of `sushy-emulator`. The actual configuration and enabling of `nginx` is done by the application layer, but the package will be available as part of the default set of packages on any Virtual Blade.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves [VSHA-676](https://jira-pro.it.hpe.com:8443/browse/VSHA-676)

## Testing

Tested on OpenCHAMI on vTDS (along with changes to that applicaiton layer implmentation) and verified that this fixed the network issues I was seeing when using `magellan collect` to discover components through `sushy-emulator`. 